### PR TITLE
优化使用 SRAM 时的源文件包含逻辑

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -110,6 +110,7 @@ if GetDepend(['BSP_USING_DSI']):
 
 if GetDepend(['BSP_USING_SRAM']):
     src += [os.path.join(src_path, 'stm32h5xx_hal_sram.c')]
+    src += [os.path.join(src_path, 'stm32h5xx_ll_fmc.c')]
     
 group = DefineGroup('STM32H5-HAL', src, depend = ['PKG_USING_STM32H5_HAL_DRIVER'], CPPPATH = path, CPPDEFINES = CPPDEFINES)
 


### PR DESCRIPTION
`HAL_SRAM_Init` 中会调用 `FMC_NORSRAM_Init` ，而 `FMC_NORSRAM_Init` 存在于 `stm32h5xx_ll_fmc.c` 中

因此，当使用 SRAM 时需要同时包含 `stm32h5xx_hal_sram.c` 以及 `stm32h5xx_ll_fmc.c` 两个文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced STM32H5 build configuration to include external memory driver support when SRAM functionality is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->